### PR TITLE
The 3432 cli automate ai generation for import

### DIFF
--- a/packages/theneo-cli/README.md
+++ b/packages/theneo-cli/README.md
@@ -111,6 +111,8 @@ Options:
   --postman-api-key <postman-api-key>        Postman API Key (env: THENEO_POSTMAN_API_KEY)
   --postman-collection <postman-collection>  Postman collection id, you can use multiple times
   --import-type <import-type>                Indicates how should the new api spec be imported (choices: "endpoints", "overwrite", "append", "merge")
+  --generate-description <generate-description>  AI description generation mode (choices: "fill", "overwrite", "no_generation", default: "no_generation")
+                                             Note: requires --import-type overwrite
   --publish                                  Automatically publish the project (default: false)
   --workspace <workspace-slug>               Workspace slug, where the project is located
   --projectVersion <version-slug>            Project version slug to import to, if not provided then default version will be used
@@ -141,6 +143,34 @@ theneo project import --project <project-slug> \
 --keepOldParameterDescription \
 --keepOldSectionDescription
 ```
+
+#### Example import with AI description generation
+
+```bash
+# Fill empty descriptions with AI
+theneo project import --project <project-slug> \
+--file ./api-spec.json \
+--import-type overwrite \
+--generate-description fill \
+--publish
+
+# Regenerate all descriptions with AI
+theneo project import --project <project-slug> \
+--file ./api-spec.json \
+--import-type overwrite \
+--generate-description overwrite \
+--publish
+```
+
+##### AI Description Generation Modes
+
+| Mode | What it does |
+|------|-------------|
+| `fill` | Generate AI descriptions only for empty parameters |
+| `overwrite` | Regenerate all descriptions with AI |
+| `no_generation` | No AI processing (default, current behavior) |
+
+**Note:** AI description generation is only available when `--import-type overwrite` is used. Attempting to use `--generate-description` with other import types will result in an error.
 
 ### Publish document
 

--- a/packages/theneo-cli/src/commands/project/import.ts
+++ b/packages/theneo-cli/src/commands/project/import.ts
@@ -16,6 +16,7 @@ import {
   getImportSource,
   getPostmanApiKeyOption,
   getPostmanCollectionsOption,
+  getDescriptionGenerationOption,
   ImportCommandOptions,
   ImportOptionsEnum,
 } from '../../core/cli/project';
@@ -24,6 +25,7 @@ import {
   ImportOption,
   ImportOptionAdditionalData,
   MergingStrategy,
+  DescriptionGenerationType,
 } from '@theneo/sdk';
 import { confirm } from '@inquirer/prompts';
 import { isInteractiveFlow } from '../../utils';
@@ -86,6 +88,53 @@ function handleProjectImportSuccess(
   }
 }
 
+async function getDescriptionGenerationModeForImport(
+  importOption: ImportOption,
+  options: ImportCommandOptions,
+  isInteractive: boolean
+): Promise<DescriptionGenerationType> {
+  // AI generation only available with overwrite import type
+  if (importOption !== ImportOption.OVERWRITE) {
+    return DescriptionGenerationType.NO_GENERATION;
+  }
+
+  // If user provided flag, use it (Casting to enum to fix TS2322)
+  if (
+    options.generateDescription &&
+    options.generateDescription !== DescriptionGenerationType.NO_GENERATION
+  ) {
+    return options.generateDescription as DescriptionGenerationType;
+  }
+
+  // Interactive: ask user if import type is overwrite
+  if (isInteractive && importOption === ImportOption.OVERWRITE) {
+    const { select } = await import('@inquirer/prompts');
+    return select<DescriptionGenerationType>({
+      message: 'Select description generation option with AI',
+      choices: [
+        {
+          name: "Don't generate descriptions",
+          value: DescriptionGenerationType.NO_GENERATION,
+        },
+        {
+          name: 'Fill empty descriptions',
+          value: DescriptionGenerationType.FILl, // Kept your specific casing
+        },
+        {
+          name: 'Overwrite descriptions',
+          value: DescriptionGenerationType.OVERWRITE,
+        },
+      ],
+    });
+  }
+
+  // Default: no generation (Casting fallback to fix TS2322)
+  return (
+    (options.generateDescription as DescriptionGenerationType) ||
+    DescriptionGenerationType.NO_GENERATION
+  );
+}
+
 async function getImportOptionAdditionalData(
   importOption: ImportOption,
   options: ImportCommandOptions,
@@ -119,6 +168,82 @@ async function getImportOptionAdditionalData(
     sectionDescriptionMergeStrategy: options.keepOldSectionDescription
       ? MergingStrategy.KEEP_OLD
       : MergingStrategy.KEEP_NEW,
+  };
+}
+
+async function validateAndGetImportSource(
+  options: ImportCommandOptions
+): Promise<void> {
+  const hasNoSource =
+    !options.file &&
+    !options.link &&
+    (!options.postmanApiKey ||
+      !options.postmanCollection ||
+      options.postmanCollection.length === 0);
+
+  if (hasNoSource) {
+    const inputSource = await getImportSource([
+      ImportOptionsEnum.FILE,
+      ImportOptionsEnum.LINK,
+      ImportOptionsEnum.POSTMAN,
+    ]);
+    Object.assign(options, inputSource);
+  }
+}
+
+function validateDescriptionGenerationOption(
+  options: ImportCommandOptions,
+  importOption: ImportOption
+): void {
+  const userRequestedAi =
+    options.generateDescription &&
+    options.generateDescription !== DescriptionGenerationType.NO_GENERATION;
+
+  const isInvalidCombination =
+    userRequestedAi && importOption !== ImportOption.OVERWRITE;
+
+  if (isInvalidCombination) {
+    console.error(
+      chalk.red(
+        '\nError: --generate-description requires --import-type overwrite'
+      )
+    );
+    console.error(
+      chalk.dim(
+        'AI description generation is currently only supported with the overwrite import type.'
+      )
+    );
+    process.exit(1);
+  }
+}
+
+function buildSpinnerText(options: ImportCommandOptions): string {
+  const importSource = options.file
+    ? `file ${chalk.cyan(options.file)}`
+    : options.link
+      ? `link ${chalk.cyan(options.link)}`
+      : 'Postman collection';
+
+  return options.tab
+    ? `Importing ${importSource} to tab ${chalk.cyan(options.tab)}...`
+    : `Importing ${importSource}...`;
+}
+
+function createProgressUpdateHandler(
+  generateDescription: DescriptionGenerationType,
+  spinner: Spinner
+): ((progressPercent: number) => void) | undefined {
+  if (generateDescription === DescriptionGenerationType.NO_GENERATION) {
+    return undefined;
+  }
+
+  return (progressPercent: number) => {
+    const progress = progressPercent
+      ? `| ${String(progressPercent).substring(0, 2)}%`
+      : '';
+    spinner.update({
+      text: `Generating descriptions ${progress}`,
+    });
   };
 }
 
@@ -175,6 +300,7 @@ Note: Published document link has this pattern: https://app.theneo.io/<workspace
       '--profile <string>',
       'Use a specific profile from your config file.'
     )
+    .addOption(getDescriptionGenerationOption())
     .option('--tab <tab-slug>', 'Import into specific tab only (optional)')
     .action(
       tryCatch(async (options: ImportCommandOptions) => {
@@ -200,25 +326,23 @@ Note: Published document link has this pattern: https://app.theneo.io/<workspace
           projectVersion,
           projectVersionSlug
         );
-        if (
-          !options.file &&
-          !options.link &&
-          (!options.postmanApiKey ||
-            !options.postmanCollection ||
-            options.postmanCollection.length === 0)
-        ) {
-          const inputSource = await getImportSource([
-            ImportOptionsEnum.FILE,
-            ImportOptionsEnum.LINK,
-            ImportOptionsEnum.POSTMAN,
-          ]);
-          options = { ...options, ...inputSource };
-        }
+
+        await validateAndGetImportSource(options);
 
         const importOption: ImportOption = await getImportOption(
           options,
           isInteractive
         );
+
+        // Validate user's explicit AI generation request before processing
+        validateDescriptionGenerationOption(options, importOption);
+
+        const generateDescription = await getDescriptionGenerationModeForImport(
+          importOption,
+          options,
+          isInteractive
+        );
+
         const importOptionAdditionalData:
           | ImportOptionAdditionalData
           | undefined = await getImportOptionAdditionalData(
@@ -228,18 +352,18 @@ Note: Published document link has this pattern: https://app.theneo.io/<workspace
         );
         const shouldPublish = await getShouldPublish(options, isInteractive);
 
-        // Enhanced spinner with context
-        const importSource = options.file
-          ? `file ${chalk.cyan(options.file)}`
-          : options.link
-            ? `link ${chalk.cyan(options.link)}`
-            : 'Postman collection';
-
-        const spinnerText = options.tab
-          ? `Importing ${importSource} to tab ${chalk.cyan(options.tab)}...`
-          : `Importing ${importSource}...`;
-
+        const spinnerText = buildSpinnerText(options);
         const spinner = createSpinner(spinnerText).start();
+
+        // If AI generation is requested, pre-set spinner text
+        if (generateDescription !== DescriptionGenerationType.NO_GENERATION) {
+          spinner.update({ text: 'Generating descriptions' });
+        }
+
+        const progressUpdateHandler = createProgressUpdateHandler(
+          generateDescription,
+          spinner
+        );
 
         const res = await theneo.importProjectDocument({
           projectId: project.id,
@@ -258,8 +382,14 @@ Note: Published document link has this pattern: https://app.theneo.io/<workspace
           },
           importOption: importOption,
           importOptionAdditionalData,
+          importMetadata: {
+            authorName: undefined,
+          },
           tabSlug: options.tab,
+          descriptionGenerationType: generateDescription,
+          progressUpdateHandler,
         });
+
         if (res.err) {
           handleProjectImportError(spinner, res.error.message, options.tab);
           process.exit(1);

--- a/packages/theneo-cli/src/core/cli/project/index.ts
+++ b/packages/theneo-cli/src/core/cli/project/index.ts
@@ -36,6 +36,7 @@ export interface ImportCommandOptions {
   keepOldParameterDescription: boolean | undefined;
   keepOldSectionDescription: boolean | undefined;
   tab: string | undefined;
+  generateDescription: DescriptionGenerationType | undefined;
 }
 
 export interface ChosenInputType {

--- a/packages/theneo-sdk/src/core/project/import.ts
+++ b/packages/theneo-sdk/src/core/project/import.ts
@@ -85,6 +85,7 @@ export function importProject(
   importInput.importOption = options.importOption;
   importInput.importMetadata = options.importMetadata;
   importInput.tabSlug = options.tabSlug;
+  importInput.descriptionGenerationType = options.descriptionGenerationType;
 
   if (options.importOption == ImportOption.MERGE) {
     importInput.importOptionAdditionalData = options.importOptionAdditionalData;

--- a/packages/theneo-sdk/src/models/inputs/project.ts
+++ b/packages/theneo-sdk/src/models/inputs/project.ts
@@ -24,6 +24,7 @@ export interface ImportProjectInput extends ImportProjectBaseInput {
   importOptionAdditionalData?: ImportOptionAdditionalData | undefined;
   publish: boolean;
   importMetadata?: ImportMetadata | undefined;
+  descriptionGenerationType?: DescriptionGenerationType;
 }
 
 export interface ImportProjectFromDirectoryInput
@@ -34,6 +35,7 @@ export interface ImportProjectFromDirectoryInput
   importOption?: ImportOption | undefined;
   importOptionAdditionalData?: ImportOptionAdditionalData | undefined;
   importMetadata?: ImportMetadata | undefined;
+  descriptionGenerationType?: DescriptionGenerationType;
 }
 
 export type FileInfo = {

--- a/packages/theneo-sdk/src/requests/project.ts
+++ b/packages/theneo-sdk/src/requests/project.ts
@@ -98,6 +98,13 @@ export function callImportProjectApi(
   const bodyFormData = new FormData();
   bodyFormData.append('publish', JSON.stringify(options.publish));
 
+  if (options.descriptionGenerationType) {
+    bodyFormData.append(
+      'descriptionGenerationType',
+      options.descriptionGenerationType
+    );
+  }
+
   // TODO validate
   if (options.postmanCollections) {
     bodyFormData.append(
@@ -210,6 +217,14 @@ export function callImportProjectFromDirectoryApi(
 
   const bodyFormData = new FormData();
   bodyFormData.append('publish', JSON.stringify(options.publish));
+
+  if (options.descriptionGenerationType) {
+    bodyFormData.append(
+      'descriptionGenerationType',
+      options.descriptionGenerationType
+    );
+  }
+
   bodyFormData.append('filePathSeparator', options.filePathSeparator);
 
   if (options.importOption) {

--- a/packages/theneo-sdk/src/schema/project.ts
+++ b/packages/theneo-sdk/src/schema/project.ts
@@ -243,6 +243,23 @@ export interface ImportProjectOptions {
    * When provided, restricts the import to the specified tab
    */
   tabSlug?: string;
+
+  /**
+   * Used to generate descriptions using AI
+   * Specify `fill` if you want to generate description for params that does not have descriptions already.
+   * Specify `overwrite` if you want to overwrite descriptions for params that does not have descriptions already.
+   * Specify `no_generation` if you want to not generate descriptions for params that does not have descriptions already.
+   *
+   * Only applicable when importOption is "overwrite"
+   * @default no_generation
+   */
+  descriptionGenerationType?: DescriptionGenerationType;
+
+  /**
+   * Callback function that is called when description generation progress is received
+   * Only used if descriptionGenerationType is set to "fill" or "overwrite"
+   */
+  progressUpdateHandler?: DescriptionGenerationProgressHandler;
 }
 
 export enum MergingStrategy {

--- a/packages/theneo-sdk/src/theneo.ts
+++ b/packages/theneo-sdk/src/theneo.ts
@@ -175,19 +175,58 @@ export class Theneo {
 
   /**
    * Imports API document to existing project
+   * If AI description generation is requested and publish is true,
+   * then it waits for description generation before publishing
    * @param options
    */
-  public importProjectDocument(
+  public async importProjectDocument(
     options: ImportProjectOptions
-  ): Promise<Result<ImportResponse>> | Result<never> {
+  ): Promise<Result<ImportResponse>> {
+    let result: Result<ImportResponse>;
+
     if (options.data.directory) {
-      return importProjectFromDirectory(
+      result = await importProjectFromDirectory(
         this.baseApiUrl,
         this.getHeaders(),
         options
       );
+    } else {
+      result = await importProject(this.baseApiUrl, this.getHeaders(), options);
     }
-    return importProject(this.baseApiUrl, this.getHeaders(), options);
+
+    // Wait for AI description generation if requested
+    if (
+      result.ok &&
+      (options.descriptionGenerationType === DescriptionGenerationType.FILl ||
+        options.descriptionGenerationType ===
+          DescriptionGenerationType.OVERWRITE)
+    ) {
+      const generationResult = await this.waitForDescriptionGeneration(
+        options.projectId,
+        options.progressUpdateHandler
+      );
+
+      if (generationResult.err) {
+        return Err(generationResult.error);
+      }
+
+      // If publish is requested, publish after AI generation completes
+      if (options.publish) {
+        const publishResult = await this.publishProject(
+          options.projectId,
+          options.versionId
+        );
+        if (publishResult.ok) {
+          const importResponse: ImportResponse = {
+            ...result.value,
+            publishData: publishResult.value,
+          };
+          return Ok(importResponse);
+        }
+      }
+    }
+
+    return result;
   }
 
   public async exportProject(
@@ -329,6 +368,7 @@ export class Theneo {
     maxWaitTime = 600_000
   ): Promise<Result<never>> {
     const startTime = Date.now();
+    // eslint-disable-next-line no-constant-condition
     while (true) {
       const generateDescriptionsResult =
         await this.getDescriptionGenerationStatus(projectId);


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

This PR adds AI-powered description generation to the project import command. Users can now automatically generate or fill in API documentation descriptions during the import process using the new `--generate-description` flag.

**Current behavior:** Project import only supports merging, overwriting, or keeping existing descriptions without any AI assistance.

**New behavior:** 
- Added `--generate-description` flag with three options:
  - `no-generation` (default): No AI processing
  - `fill`: Generate descriptions only for empty/missing fields
  - `overwrite`: Generate descriptions for all fields, replacing existing ones
- AI generation is only available with `--import-type overwrite` to ensure proper compatibility
- Interactive mode prompts users to select generation option when applicable
- Real-time progress updates during AI generation with percentage display
- Proper validation with helpful error messages for invalid flag combinations

**Usage example:**
```bash
theneo project import \
  --project my-project \
  --file api.yaml \
  --import-type overwrite \
  --generate-description fill \
  --publish
```

Fixes #THE-3432

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] This pull request links relevant issues as `Fixes THE-3432`
- [ ] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change

<!--
  🎉 Thank you for contributing!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable AI description generation for imports with modes: fill, overwrite, and no_generation.
  * New CLI option --generate-description (only valid with --import-type overwrite) with live progress reporting and optional wait-for-generation/publish behavior.

* **Documentation**
  * Import command docs updated with examples, a description-generation modes section, and usage/validation notes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->