### PR TITLE
introducing merge v 2.0 THE-4049

### DIFF
--- a/packages/theneo-cli/README.md
+++ b/packages/theneo-cli/README.md
@@ -110,12 +110,13 @@ Options:
   --link <link>                              API file URL to create project using it
   --postman-api-key <postman-api-key>        Postman API Key (env: THENEO_POSTMAN_API_KEY)
   --postman-collection <postman-collection>  Postman collection id, you can use multiple times
-  --import-type <import-type>                Indicates how should the new api spec be imported (choices: "endpoints", "overwrite", "append", "merge")
+  --import-type <import-type>                How to import the spec (choices: "endpoints", "overwrite", "append", "merge", "merge_v2")
+  --description-merge-strategy <strategy>    For merge_v2: keep_new or keep_old (default: keep_new)
   --publish                                  Automatically publish the project (default: false)
   --workspace <workspace-slug>               Workspace slug, where the project is located
   --projectVersion <version-slug>            Project version slug to import to, if not provided then default version will be used
-  --keepOldParameterDescription              Additional flag during merging import option, it will keep old parameter descriptions
-  --keepOldSectionDescription                Additional flag during merging import option, it will keep old section descriptions
+  --keepOldParameterDescription              For merge: keep existing parameter descriptions
+  --keepOldSectionDescription                For merge: keep existing section descriptions
   --profile <string>                         Use a specific profile from your config file.
   -h, --help                                 display help for command
 ```
@@ -140,6 +141,13 @@ theneo project import --project <project-slug> \
 --import-type merge \
 --keepOldParameterDescription \
 --keepOldSectionDescription
+```
+
+#### Example import with merge_v2 (smart merge)
+
+```bash
+theneo project import --project <project-slug> --file openapi.yaml --import-type merge_v2
+theneo project import --project <project-slug> --file openapi.yaml --import-type merge_v2 --description-merge-strategy keep_old
 ```
 
 ### Publish document

--- a/packages/theneo-cli/package.json
+++ b/packages/theneo-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theneo/cli",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Theneo CLI",
   "keywords": [
     "theneo",

--- a/packages/theneo-cli/src/commands/project/import.ts
+++ b/packages/theneo-cli/src/commands/project/import.ts
@@ -9,6 +9,7 @@ import {
   getShouldPublish,
 } from '../../core/cli/project/project';
 import {
+  createDescriptionMergeStrategyOption,
   createFileOption,
   createImportTypeOption,
   createLinkOption,
@@ -28,6 +29,41 @@ import {
 import { confirm } from '@inquirer/prompts';
 import { isInteractiveFlow } from '../../utils';
 import { createNewProjectVersion } from '../../core/cli/version/create';
+
+const MERGE_V2_IMPORT_OPTION = 'merge_v2';
+const SPINNER_MESSAGE_MERGE_V2 =
+  'Updating documentation (merge_v2 smart merge)...';
+
+function isMergeV2Import(importOption: ImportOption): boolean {
+  return String(importOption) === MERGE_V2_IMPORT_OPTION;
+}
+
+function hasNoImportSource(options: ImportCommandOptions): boolean {
+  const hasFile = Boolean(options.file);
+  const hasLink = Boolean(options.link);
+  const hasPostman =
+    Boolean(options.postmanApiKey) &&
+    Array.isArray(options.postmanCollection) &&
+    options.postmanCollection.length > 0;
+  return !hasFile && !hasLink && !hasPostman;
+}
+
+function getImportSpinnerText(
+  options: ImportCommandOptions,
+  importOption: ImportOption
+): string {
+  if (isMergeV2Import(importOption)) {
+    return SPINNER_MESSAGE_MERGE_V2;
+  }
+  const importSource = options.file
+    ? `file ${chalk.cyan(options.file)}`
+    : options.link
+      ? `link ${chalk.cyan(options.link)}`
+      : 'Postman collection';
+  return options.tab
+    ? `Importing ${importSource} to tab ${chalk.cyan(options.tab)}...`
+    : `Importing ${importSource}...`;
+}
 
 function handleProjectImportError(
   spinner: Spinner,
@@ -91,6 +127,17 @@ async function getImportOptionAdditionalData(
   options: ImportCommandOptions,
   isInteractive: boolean
 ): Promise<ImportOptionAdditionalData | undefined> {
+  if (importOption === ImportOption.MERGE_V2) {
+    const strategy =
+      options.descriptionMergeStrategy === 'keep_old'
+        ? MergingStrategy.KEEP_OLD
+        : MergingStrategy.KEEP_NEW;
+    return {
+      parameterDescriptionMergeStrategy: strategy,
+      sectionDescriptionMergeStrategy: strategy,
+    };
+  }
+
   if (isInteractive && importOption === ImportOption.MERGE) {
     if (options.keepOldParameterDescription === undefined) {
       options.keepOldParameterDescription = await confirm({
@@ -100,7 +147,7 @@ async function getImportOptionAdditionalData(
 
     if (options.keepOldSectionDescription === undefined) {
       options.keepOldSectionDescription = await confirm({
-        message: 'Keep old parameter descriptions?',
+        message: 'Keep old section descriptions?',
       });
     }
   }
@@ -150,6 +197,7 @@ Note: Published document link has this pattern: https://app.theneo.io/<workspace
     .addOption(getPostmanApiKeyOption())
     .addOption(getPostmanCollectionsOption())
     .addOption(createImportTypeOption())
+    .addOption(createDescriptionMergeStrategyOption())
     .option('--publish', 'Automatically publish the project', false)
     .option(
       '--workspace <workspace-slug>',
@@ -200,13 +248,7 @@ Note: Published document link has this pattern: https://app.theneo.io/<workspace
           projectVersion,
           projectVersionSlug
         );
-        if (
-          !options.file &&
-          !options.link &&
-          (!options.postmanApiKey ||
-            !options.postmanCollection ||
-            options.postmanCollection.length === 0)
-        ) {
+        if (hasNoImportSource(options)) {
           const inputSource = await getImportSource([
             ImportOptionsEnum.FILE,
             ImportOptionsEnum.LINK,
@@ -228,19 +270,9 @@ Note: Published document link has this pattern: https://app.theneo.io/<workspace
         );
         const shouldPublish = await getShouldPublish(options, isInteractive);
 
-        // Enhanced spinner with context
-        const importSource = options.file
-          ? `file ${chalk.cyan(options.file)}`
-          : options.link
-            ? `link ${chalk.cyan(options.link)}`
-            : 'Postman collection';
-
-        const spinnerText = options.tab
-          ? `Importing ${importSource} to tab ${chalk.cyan(options.tab)}...`
-          : `Importing ${importSource}...`;
-
-        const spinner = createSpinner(spinnerText).start();
-
+        const spinner = createSpinner(
+          getImportSpinnerText(options, importOption)
+        ).start();
         const res = await theneo.importProjectDocument({
           projectId: project.id,
           versionId: projectVersionId,

--- a/packages/theneo-cli/src/core/cli/project/index.ts
+++ b/packages/theneo-cli/src/core/cli/project/index.ts
@@ -36,7 +36,12 @@ export interface ImportCommandOptions {
   keepOldParameterDescription: boolean | undefined;
   keepOldSectionDescription: boolean | undefined;
   tab: string | undefined;
+  descriptionMergeStrategy: DescriptionMergeStrategy | undefined;
 }
+
+export const DESCRIPTION_MERGE_STRATEGIES = ['keep_new', 'keep_old'] as const;
+export type DescriptionMergeStrategy =
+  (typeof DESCRIPTION_MERGE_STRATEGIES)[number];
 
 export interface ChosenInputType {
   file?: string;
@@ -213,7 +218,21 @@ export const IMPORT_OPTIONS_AND_DESCRIPTIONS: {
     description:
       'Merge the current API spec with the new API spec - experimental',
   },
+  {
+    option: ImportOption.MERGE_V2,
+    description:
+      'Smart merge - only update sections where API contract changed (merge_v2)',
+  },
 ];
+
+export function createDescriptionMergeStrategyOption(): Option {
+  return new Option(
+    '--description-merge-strategy <strategy>',
+    'For merge_v2: keep_new (prefer new spec descriptions) or keep_old (preserve existing)'
+  )
+    .choices([...DESCRIPTION_MERGE_STRATEGIES])
+    .default('keep_new');
+}
 
 export function getImportOption(
   options: { importType: ImportOption | undefined },

--- a/packages/theneo-sdk/package.json
+++ b/packages/theneo-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theneo/sdk",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Theneo SDK",
   "keywords": [
     "theneo",

--- a/packages/theneo-sdk/src/core/project/import.ts
+++ b/packages/theneo-sdk/src/core/project/import.ts
@@ -22,6 +22,25 @@ import {
   getAllFilesFromDirectory,
   getFilePath,
 } from 'theneo/utils/file';
+import type { ImportOptionAdditionalData } from '../../schema/project';
+
+function usesMergeWithAdditionalData(
+  option: ImportProjectOptions['importOption']
+): boolean {
+  return option === ImportOption.MERGE || option === ImportOption.MERGE_V2;
+}
+
+function withDefaultMergeStrategies(
+  data?: ImportOptionAdditionalData
+): ImportOptionAdditionalData {
+  return {
+    ...data,
+    parameterDescriptionMergeStrategy:
+      data?.parameterDescriptionMergeStrategy ?? MergingStrategy.KEEP_NEW,
+    sectionDescriptionMergeStrategy:
+      data?.sectionDescriptionMergeStrategy ?? MergingStrategy.KEEP_NEW,
+  };
+}
 
 export function importProjectFromDirectory(
   baseUrl: string,
@@ -86,23 +105,10 @@ export function importProject(
   importInput.importMetadata = options.importMetadata;
   importInput.tabSlug = options.tabSlug;
 
-  if (options.importOption == ImportOption.MERGE) {
-    importInput.importOptionAdditionalData = options.importOptionAdditionalData;
-    if (!importInput.importOptionAdditionalData) {
-      importInput.importOptionAdditionalData = {};
-    }
-    if (
-      !importInput.importOptionAdditionalData.parameterDescriptionMergeStrategy
-    ) {
-      importInput.importOptionAdditionalData.parameterDescriptionMergeStrategy =
-        MergingStrategy.KEEP_NEW;
-    }
-    if (
-      !importInput.importOptionAdditionalData.sectionDescriptionMergeStrategy
-    ) {
-      importInput.importOptionAdditionalData.sectionDescriptionMergeStrategy =
-        MergingStrategy.KEEP_NEW;
-    }
+  if (usesMergeWithAdditionalData(options.importOption)) {
+    importInput.importOptionAdditionalData = withDefaultMergeStrategies(
+      options.importOptionAdditionalData
+    );
   }
 
   return callImportProjectApi(

--- a/packages/theneo-sdk/src/schema/project.ts
+++ b/packages/theneo-sdk/src/schema/project.ts
@@ -210,6 +210,8 @@ export enum ImportOption {
   OVERWRITE = 'overwrite',
   APPEND = 'append',
   MERGE = 'merge',
+  /** Smart merge: only updates sections where the API contract changed (fingerprint-based). */
+  MERGE_V2 = 'merge_v2',
 }
 
 export interface ImportMetadata {


### PR DESCRIPTION

Adds merge_v2 (smart merge) as a new import strategy in the Theneo CLI and SDK. The backend already supports it; this change exposes it in the CLI and keeps the codebase in good shape for a public repo.

**What changed**

SDK (packages/theneo-sdk)
ImportOption enum – New value MERGE_V2 = 'merge_v2' with a short JSDoc describing smart merge (fingerprint-based, only updates where the API contract changed).
Import flow – When importOption is merge or merge_v2, the SDK sends importOptionAdditionalData (description merge strategies) and applies defaults (KEEP_NEW) when not provided. Logic is in two helpers: usesMergeWithAdditionalData() and withDefaultMergeStrategies() for clarity and reuse.

CLI (packages/theneo-cli)
New import type – --import-type merge_v2 is a valid choice. Shown in help as: “Smart merge - only update sections where API contract changed (merge_v2)”.
Description merge strategy – New flag --description-merge-strategy <strategy> with choices keep_new (default) and keep_old. Used only when merge_v2 is selected; sent as importOptionAdditionalData (JSON) to the backend.
Bug fix – For the legacy merge option, the second interactive prompt now correctly says “Keep old section descriptions?” instead of “parameter”.

Refactors 
Constants for merge_v2 and spinner messages; isMergeV2Import(), hasNoImportSource(); exported DescriptionMergeStrategy type and DESCRIPTION_MERGE_STRATEGIES for the strategy option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new "merge_v2" import option for smart API spec merging that updates only changed sections
  * Added "--description-merge-strategy" CLI option to control how descriptions are merged during imports (keep_new or keep_old)

* **Documentation**
  * Updated CLI help text with clearer descriptions and new examples demonstrating merge_v2 workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->